### PR TITLE
Remove duplicate page prefixes

### DIFF
--- a/src/utils/getUrlSlug.js
+++ b/src/utils/getUrlSlug.js
@@ -6,5 +6,7 @@ export default function getUrlSlug(slugPartsArrayOrString) {
     return process.env.PUBLIC_URL || "/"
   }
 
-  return process.env.PUBLIC_URL + (slug.startsWith("/") ? slug : `/${slug}`)
+  const slugWithSlash = slug.startsWith("/") ? slug : `/${slug}`;
+
+  return slugWithSlash.startsWith(process.env.PUBLIC_URL) ? slugWithSlash : `${process.env.PUBLIC_URL}${slugWithSlash}`;
 }


### PR DESCRIPTION
### Motivation

Fix paging -> urls for paging contained 2 PUBLIC_URL prefixes

![image](https://user-images.githubusercontent.com/9218736/144055100-33a58fec-2dc1-4aa5-b5d1-9faa9435e550.png)

Also visible on the published version.